### PR TITLE
Feature/remove timeout

### DIFF
--- a/robotx_driver/include/robotx_hardware_interface.h
+++ b/robotx_driver/include/robotx_hardware_interface.h
@@ -266,6 +266,11 @@ class robotx_hardware_interface {
    */
   remote_operated_interface remote_operated_if;
   /**
+   * @brief io_service_thread
+   *
+   */
+  boost::thread io_service_thread_;
+  /**
    * @brief send_command_thread
    *
    */

--- a/robotx_driver/src/tcp_client.cpp
+++ b/robotx_driver/src/tcp_client.cpp
@@ -54,6 +54,10 @@ void tcp_client::on_connect(const boost::system::error_code &error) {
 }
 
 void tcp_client::on_receive(const boost::system::error_code &error, size_t bytes_transferred) {
+    if (error) {
+      ROS_ERROR_STREAM(error.message());
+    }
+  /*
   if (error == boost::asio::error::operation_aborted) {
     ROS_ERROR_STREAM("timeout"
                      << "(" << ip_address_ << ":" << port_ << ")");
@@ -64,6 +68,7 @@ void tcp_client::on_receive(const boost::system::error_code &error, size_t bytes
       ROS_ERROR_STREAM(error.message());
     }
   }
+  */
 }
 
 void tcp_client::send(double data) {
@@ -105,6 +110,6 @@ void tcp_client::start_receive() {
   boost::asio::async_read(socket_, receive_buff_, boost::asio::transfer_all(),
                           boost::bind(&tcp_client::on_receive, this, boost::asio::placeholders::error,
                                       boost::asio::placeholders::bytes_transferred));
-  timer_.expires_from_now(std::chrono::seconds(timeout_));
-  timer_.async_wait(boost::bind(&tcp_client::on_timer, this, _1));
+  //timer_.expires_from_now(std::chrono::seconds(timeout_));
+  //timer_.async_wait(boost::bind(&tcp_client::on_timer, this, _1));
 }


### PR DESCRIPTION
timeout for tcp client is unnecessary.
So, we remove this function.